### PR TITLE
Add Single Server adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,58 +5,43 @@
 ### AWS
 Nanobox officially supports deploying apps to [Amazon Web Services (AWS)](https://aws.amazon.com/). You can select AWS as a provider in the Nanobox Dashboard.
 
-**Adapter Repo**  
-https://github.com/nanobox-io/nanobox-adapter-aws
-
-**Contributors**  
-[@jedgalbraith](https://github.com/jedgalbraith)
+- **Adapter Repo**: https://github.com/nanobox-io/nanobox-adapter-aws
+- **Contributors**: [@jedgalbraith](https://github.com/jedgalbraith)
 
 ### DigitalOcean
 Nanobox officially supports deploying apps to [DigitalOcean](https://www.digitalocean.com/). You can select DigitalOcean as a provider in the Nanobox Dashboard.
 
-**Adapter Repo:**  
-https://github.com/nanobox-io/nanobox-adapter-digitalocean
+- **Adapter Repo**: https://github.com/nanobox-io/nanobox-adapter-digitalocean
+- **Contributors**: [@tylerflint](https://github.com/tylerflint)
 
-**Contributors**  
-[@tylerflint](https://github.com/tylerflint)
+### Linode _(Beta)_
+Nanobox is testing official support for deploying apps to [Linode](https://www.linode.com/). You can select Linode as a provider in the Nanobox Dashboard.
 
-### Linode *(In Progress)*
-Nanobox is building out official support for deploying apps to [Linode](https://www.linode.com/). You will be able to select Linode as a provider in the Nanobox Dashboard.
-
-**Adapter Repo:**  
-https://github.com/nanobox-io/nanobox-adapter-linode
-
-**Contributors**  
-[@jedgalbraith](https://github.com/jedgalbraith), [@lyondhill](https://github.com/lyondhill)
+- **Adapter Repo**: https://github.com/nanobox-io/nanobox-adapter-linode
+- **Contributors**: [@jedgalbraith](https://github.com/jedgalbraith), [@lyondhill](https://github.com/lyondhill)
 
 ## Community Integrations
 
 ### Proxmox
 [Proxmox](https://www.proxmox.com/en/) is an open source cloud solution that allows you to build and manage your own virtual cloud. Proxmox can be used as a custom provider in the Nanobox dashboard.
 
-**Provider Endpoint**  
-https://adapter-proxmox.nanoapp.io/api/v1/
+- **Provider Endpoint**: https://adapter-proxmox.nanoapp.io/api/v1/
+- **Documentation**: https://adapter-proxmox.nanoapp.io/
+- **Adapter Repo**: https://github.com/danhunsaker/nanobox-adapter-proxmox
+- **Contributors**: [@danhunsaker](https://github.com/danhunsaker)
 
-**Documentation**  
-https://adapter-proxmox.nanoapp.io/
+### Single Server
+In those cases where you have hosting with a provider that isn't listed here, but still want to deploy with Nanobox, install this adapter on that server, following the instructions in the documentation, and then connect directly to it when adding it as your provider. Single Server can be used as a custom provider in the Nanobox dashboard.
 
-**Adapter Repo**  
-https://github.com/danhunsaker/nanobox-adapter-proxmox
+- **Provider Endpoint**: https://{your-server-ip}:8000/ _(this adapter is installed on the same server you plan to deploy to)_
+- **Documentation**: https://github.com/torfs-ict/nanobox-adapter-single-server/blob/master/README.md
+- **Adapter Repo**: https://github.com/torfs-ict/nanobox-adapter-single-server
+- **Contributors**: [@torfs-ict](https://github.com/torfs-ict)
 
-**Contributors**  
-[@danhunsaker](https://github.com/danhunsaker)
-
-### Google Cloud *(In Progress)*
+### Google Cloud _(In Progress)_
 This integration is in the works but will allow Nanobox users to deploy to [Google Cloud](https://cloud.google.com/).
 
-**Provider Endpoint**  
-*Coming*
-
-**Documentation**  
-*Coming*
-
-**Adapter Repo**  
-https://github.com/jeffgodwyll/nanobox-googlecloud-adapter
-
-**Contributors**  
-[@jeffgodwyll](https://github.com/jeffgodwyll)
+- **Provider Endpoint**: *Coming*
+- **Documentation**: *Coming*
+- **Adapter Repo**: https://github.com/jeffgodwyll/nanobox-googlecloud-adapter
+- **Contributors**: [@jeffgodwyll](https://github.com/jeffgodwyll)


### PR DESCRIPTION
The Single Server adapter has been available for some time, but never listed anywhere for testing/use. This PR adds it.

Of course, it also does a large amount of reformatting, to improve readability. I found that it was difficult to locate the boundary between adapters, so I adjusted the formatting to make it easier to scan the page and find things quickly.

Also updated the Linode section, as it was pretty outdated by now.